### PR TITLE
fix i6_rgn.h

### DIFF
--- a/src/hal/star/i6_rgn.h
+++ b/src/hal/star/i6_rgn.h
@@ -33,7 +33,7 @@ typedef struct {
 
 typedef struct {
     i6_rgn_type type;
-    i6_common_pixfmt pixFmt;
+    i6_rgn_pixfmt pixFmt;
     i6_rgn_size size;
 } i6_rgn_cnf;
 


### PR DESCRIPTION
The enumeration type i6_common_pixfmt should be i6_rgn_pixfmt in i6_rgn_cnf